### PR TITLE
v0.8.0-alpha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM recksato/robosats-client:v0.7.9-alpha
+FROM recksato/robosats-client:v0.8.0-alpha
 RUN apk add bash curl sudo tini wget yq; \
     rm -f /var/cache/apk/*
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,8 @@
 id: robosats
 title: "RoboSats"
-version: 0.7.9
+version: 0.8.0
 release-notes: |
-  * Updated to RoboSats v0.7.9-alpha [Release Notes](https://github.com/RoboSats/robosats/releases/tag/v0.7.9-alpha)
+  * Updated to RoboSats v0.8.0-alpha [Release Notes](https://github.com/RoboSats/robosats/releases/tag/v0.8.0-alpha)
   * Enable LAN access to RoboSats web interface
 license: mit
 wrapper-repo: "https://github.com/Start9Labs/robosats-startos"

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,4 @@
 import { compat, types as T } from "../deps.ts";
 
 export const migration: T.ExpectedExports.migration =
-  compat.migrations.fromMapping({}, "0.7.9");
+  compat.migrations.fromMapping({}, "0.8.0");


### PR DESCRIPTION
Hey @gStart9 I see on the marketplace you still have Robosats v7.6.0. After coordinators upgrade to v0.8.0 clients will force users to upgrade, which will make StartOS instance unusable, how much time do you think it can take to move this one? 